### PR TITLE
Add a debug view

### DIFF
--- a/prototypes/basic/src/controllers.ts
+++ b/prototypes/basic/src/controllers.ts
@@ -122,10 +122,16 @@ export module Controllers {
       manufacturer.PRODUCT_CODE = product.PRODUCT_CODE;
     }
 
+    let debug = request.query.debug || "";
+    if (debug) {
+      debug = product;
+    }
+
     response.render("detail", {
       back: request.get("Referrer"),
       product: product,
       manufacturer: manufacturer,
+      debug: debug,
     });
   }
 }

--- a/prototypes/basic/templates/detail.mustache
+++ b/prototypes/basic/templates/detail.mustache
@@ -8,6 +8,11 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
+        {{# debug }}
+            {{> partial/debug }}
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        {{/ debug }}
+
         {{^product }}
             Product not found
         {{/ product}}

--- a/prototypes/basic/templates/partial/debug.mustache
+++ b/prototypes/basic/templates/partial/debug.mustache
@@ -1,0 +1,386 @@
+<h1>{{DEBUG}}</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-table__caption--m">Product fields</caption>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">PRODUCT_ID</th>
+      <td class="govuk-table__cell">{{ PRODUCT_ID }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEVICE_ID</th>
+      <td class="govuk-table__cell">{{ DEVICE_ID }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">MANUFACTURER_ID</th>
+      <td class="govuk-table__cell">{{ MANUFACTURER_ID }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">MANUFACTURER_NAME</th>
+      <td class="govuk-table__cell">{{ MANUFACTURER_NAME }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">BRAND_TRADE_NAME</th>
+      <td class="govuk-table__cell">{{ BRAND_TRADE_NAME }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_MODEL / MODEL</th>
+      <td class="govuk-table__cell">{{ IS_MODEL }} / {{ MODEL }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">PRODUCT_CODE</th>
+      <td class="govuk-table__cell">{{ PRODUCT_CODE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">NOTIFIED_BODY_ID</th>
+      <td class="govuk-table__cell">{{ NOTIFIED_BODY_ID }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">NOTIFIED_BODY_NAME</th>
+      <td class="govuk-table__cell">{{ NOTIFIED_BODY_NAME }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEVICE_PRODUCT_REGISTRATION_STATUS_ID</th>
+      <td class="govuk-table__cell">{{ DEVICE_PRODUCT_REGISTRATION_STATUS_ID  }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">QUANTITY_PER_PACKAGE</th>
+      <td class="govuk-table__cell">{{ QUANTITY_PER_PACKAGE  }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_STERILE</th>
+      <td class="govuk-table__cell">{{ IS_STERILE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">METHOD_STERILISATION</th>
+      <td class="govuk-table__cell">{{ METHOD_STERILISATION }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">OTHER_STERILISATION</th>
+      <td class="govuk-table__cell">{{ OTHER_STERILISATION }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">UDI_NUMBER</th>
+      <td class="govuk-table__cell">{{ UDI_NUMBER }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">UDI_ENTITY_ID</th>
+      <td class="govuk-table__cell">{{ UDI_ENTITY_ID }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">UDI_ENTITY_CODE</th>
+      <td class="govuk-table__cell">{{ UDI_ENTITY_CODE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">UDI_PI_TYPE</th>
+      <td class="govuk-table__cell">{{ UDI_PI_TYPE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">UNIT_OF_USE_UDI_DI</th>
+      <td class="govuk-table__cell">{{ UNIT_OF_USE_UDI_DI }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">SECONDARY_UDI_NUMBER</th>
+      <td class="govuk-table__cell">{{ SECONDARY_UDI_NUMBER }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">SECONDARY_UDI_ENTITY_ID</th>
+      <td class="govuk-table__cell">{{ SECONDARY_UDI_ENTITY_ID }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">SECONDARY_UDI_ENTITY_CODE</th>
+      <td class="govuk-table__cell">{{ SECONDARY_UDI_ENTITY_CODE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_DEVICE_DIRECTLY_MARKED_WITH_UDI_DI</th>
+      <td class="govuk-table__cell">{{ IS_DEVICE_DIRECTLY_MARKED_WITH_UDI_DI }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DIRECT_MARKING_DI_DIFFERENT_FROM_UDI_DI</th>
+      <td class="govuk-table__cell">{{ DIRECT_MARKING_DI_DIFFERENT_FROM_UDI_DI }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DIRECT_MARKING_DI</th>
+      <td class="govuk-table__cell">{{ DIRECT_MARKING_DI }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">PACKAGE_DI</th>
+      <td class="govuk-table__cell">{{ PACKAGE_DI }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">PACKAGE_DI_NUMBER_LEVEL1</th>
+      <td class="govuk-table__cell">{{ PACKAGE_DI_NUMBER_LEVEL1 }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">PACKAGE_TYPE_LEVEL1</th>
+      <td class="govuk-table__cell">{{ PACKAGE_TYPE_LEVEL1 }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">PACKAGE_DI_NUMBER_LEVEL2</th>
+      <td class="govuk-table__cell">{{ PACKAGE_DI_NUMBER_LEVEL2 }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">PACKAGE_TYPE_LEVEL2</th>
+      <td class="govuk-table__cell">{{ PACKAGE_TYPE_LEVEL2 }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">PACKAGE_DI_NUMBER_LEVEL3</th>
+      <td class="govuk-table__cell">{{ PACKAGE_DI_NUMBER_LEVEL3 }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">PACKAGE_TYPE_LEVEL3</th>
+      <td class="govuk-table__cell">{{ PACKAGE_TYPE_LEVEL3 }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">PRODUCT_STATUS</th>
+      <td class="govuk-table__cell">{{ PRODUCT_STATUS }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_CONTAINING_LATEX</th>
+      <td class="govuk-table__cell">{{ IS_CONTAINING_LATEX }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_CLINICAL_SIZE</th>
+      <td class="govuk-table__cell">{{ IS_CLINICAL_SIZE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">CLINICAL_SIZE_DESCRIPTION</th>
+      <td class="govuk-table__cell">{{ CLINICAL_SIZE_DESCRIPTION }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">URL_ADDITIONAL</th>
+      <td class="govuk-table__cell">{{ URL_ADDITIONAL }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_CRITICAL_WARNING</th>
+      <td class="govuk-table__cell">{{ IS_CRITICAL_WARNING }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"></th>
+      <td class="govuk-table__cell">{{ CRITICAL_WARNING_DESCRIPTION }}</td>
+    </tr>
+
+  </tbody>
+</table>
+
+
+  <table class="govuk-table">
+  <caption class="govuk-table__caption govuk-table__caption--m">Device fields</caption>
+  <tbody class="govuk-table__body">
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEVICE_ID</th>
+      <td class="govuk-table__cell">{{ DEVICE_ID }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">MAN_ORGANISATION_ID</th>
+      <td class="govuk-table__cell">{{ MAN_ORGANISATION_ID }}</td>
+    </tr>
+
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEVICE_TYPE_NAME</th>
+      <td class="govuk-table__cell">{{ DEVICE_TYPE_NAME }}</td>
+    </tr>
+
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEVICE_RISK_CLASSIFICATION_ID</th>
+      <td class="govuk-table__cell">{{ DEVICE_RISK_CLASSIFICATION_ID }}</td>
+    </tr>
+
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEVICE_RISK_SUB_TYPE_CODE</th>
+      <td class="govuk-table__cell">{{ DEVICE_RISK_SUB_TYPE_CODE }}</td>
+    </tr>
+
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEVICE_RISK_SUB_TYPE_DESC</th>
+      <td class="govuk-table__cell">{{ DEVICE_RISK_SUB_TYPE_DESC }}</td>
+    </tr>
+
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"DEVICE_RISK_IS_ACTIVE></th>
+      <td class="govuk-table__cell">{{ DEVICE_RISK_IS_ACTIVE }}</td>
+    </tr>
+
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">GMDN_ID</th>
+      <td class="govuk-table__cell">{{ GMDN_ID }}</td>
+    </tr>
+
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">GMDN_CODE</th>
+      <td class="govuk-table__cell">{{ GMDN_CODE }}</td>
+    </tr>
+
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">GMDN_TERM_NAME</th>
+      <td class="govuk-table__cell">{{ GMDN_TERM_NAME }}</td>
+    </tr>
+
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_REGISTRED_UNDER_2017_MDRS</th>
+      <td class="govuk-table__cell">{{ IS_REGISTRED_UNDER_2017_MDRS }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_CUSTOM_MADE</th>
+      <td class="govuk-table__cell">{{ IS_CUSTOM_MADE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_STERILE</th>
+      <td class="govuk-table__cell">{{ IS_STERILE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">METHOD_STERILISATION</th>
+      <td class="govuk-table__cell">{{ METHOD_STERILISATION }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">OTHER_STERILISATION</th>
+      <td class="govuk-table__cell">{{ OTHER_STERILISATION }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_MEASURING</th>
+      <td class="govuk-table__cell">{{ IS_MEASURING }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header"></th>
+      <td class="govuk-table__cell">{{ DEV_NOTIFIED_BODY_ID }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">NOTIFIED_BODY_NAME</th>
+      <td class="govuk-table__cell">{{ NOTIFIED_BODY_NAME }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEVICE_REG_STATUS_CODE</th>
+      <td class="govuk-table__cell">{{ DEVICE_REG_STATUS_CODE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">REG_DEV_STATUS</th>
+      <td class="govuk-table__cell">{{ REG_DEV_STATUS }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">SCHEDULEXVI</th>
+      <td class="govuk-table__cell">{{ SCHEDULEXVI }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">SINGLE_USE_DEVICE</th>
+      <td class="govuk-table__cell">{{ SINGLE_USE_DEVICE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEV_UDI_NUMBERS</th>
+      <td class="govuk-table__cell">{{ DEV_UDI_NUMBERS }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEV_UDI_ENTITY_ID</th>
+      <td class="govuk-table__cell">{{ DEV_UDI_ENTITY_ID }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEV_UDI_ENTITY_CODE</th>
+      <td class="govuk-table__cell">{{ DEV_UDI_ENTITY_CODE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_PERFORMANCE_STUDIES</th>
+      <td class="govuk-table__cell">{{ IS_PERFORMANCE_STUDIES }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEVICE_TYPE_CODE</th>
+      <td class="govuk-table__cell">{{ DEVICE_TYPE_CODE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEVICE_IMPLANTABLE</th>
+      <td class="govuk-table__cell">{{ DEVICE_IMPLANTABLE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">DEVICE_ACTIVE</th>
+      <td class="govuk-table__cell">{{ DEVICE_ACTIVE }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">ADMINISTER_REMOVE_MEDICINAL_PRODUCT</th>
+      <td class="govuk-table__cell">{{ ADMINISTER_REMOVE_MEDICINAL_PRODUCT }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">IS_REUSABLE_SURGICAL_INSTRUMENTS</th>
+      <td class="govuk-table__cell">{{ IS_REUSABLE_SURGICAL_INSTRUMENTS }}</td>
+    </tr>
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">MAXIMUM_NUMBER_REUSE</th>
+      <td class="govuk-table__cell">{{ MAXIMUM_NUMBER_REUSE }}</td>
+    </tr>
+
+
+  </tbody>
+</table>
+
+</div>
+</div>


### PR DESCRIPTION
When viewing /product/:id if you specify ?debug=1 then the page will contain a table of all of the fields (with values) for the product and the device.