### PR TITLE
Remove sort from browse

### DIFF
--- a/prototypes/basic/src/controllers.ts
+++ b/prototypes/basic/src/controllers.ts
@@ -114,7 +114,7 @@ export module Controllers {
 
   function browseQuery(): [string, string] {
     return [
-      `SELECT P.*, D.* FROM products AS P INNER JOIN devices as D ON D.DEVICE_ID=P.DEVICE_ID  ORDER BY P.BRAND_TRADE_NAME
+      `SELECT P.*, D.* FROM products AS P INNER JOIN devices as D ON D.DEVICE_ID=P.DEVICE_ID
      LIMIT ? OFFSET ?`,
       `SELECT COUNT(*) as total FROM products`,
     ];


### PR DESCRIPTION
When browsing results, it can take a while to load the page if we sort them by product name because of the number of records.  Instead, we'll use the default sort for the database and get a much faster response.