### PR TITLE
Add sort parameter

### DIFF
--- a/prototypes/v2/src/controllers.ts
+++ b/prototypes/v2/src/controllers.ts
@@ -134,7 +134,37 @@ export module Controllers {
       pages: pages,
       csv_download: csv_url,
       excel_download: excel_url,
+      sort: getSortOptions(fullURL),
     });
+  }
+
+  function getSortOptions(url: string): any {
+    let sort_options = {
+      relevant: "",
+      manufacturer_az: "",
+      manufacturer_za: "",
+      name_az: "",
+      name_za: "",
+    };
+
+    let sortURL = new URL(url);
+    sortURL.searchParams.delete("page");
+    sortURL.searchParams.delete("sort");
+    sort_options.relevant = sortURL.toString();
+
+    sortURL.searchParams.set("sort", "manufacturer");
+    sort_options.manufacturer_az = sortURL.toString();
+
+    sortURL.searchParams.set("sort", "-manufacturer");
+    sort_options.manufacturer_za = sortURL.toString();
+
+    sortURL.searchParams.set("sort", "name");
+    sort_options.name_az = sortURL.toString();
+
+    sortURL.searchParams.set("sort", "-name");
+    sort_options.name_za = sortURL.toString();
+
+    return sort_options;
   }
 
   function browseQuery(): [string, string] {

--- a/prototypes/v2/templates/search.mustache
+++ b/prototypes/v2/templates/search.mustache
@@ -45,9 +45,9 @@
             Sort results
           </label>
           <select class="govuk-select" id="sort" name="sort">
-            <option value="updated" selected>Most relevant</option>
-            <option value="views">Product name (A to Z)</option>
-            <option value="comments">Manufacturer name (A to Z)</option>
+            <option value="{{ sort.relevant }}" selected>Most relevant</option>
+            <option value="{{ sort.name_az }}">Product name (A to Z)</option>
+            <option value="{{ sort.manufacturer_az }}">Manufacturer name (A to Z)</option>
           </select>
         </div>
         <h2 class="govuk-heading-s">Filter results</h2>
@@ -568,7 +568,7 @@
                     </div>
                   </fieldset>
                 </div>
-                
+
                 <div class="govuk-form-group">
                   <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
@@ -783,9 +783,9 @@
             </div>
           </div>
         </details>
-        
+
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-        
+
         <details class="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">

--- a/prototypes/v2/templates/search.mustache
+++ b/prototypes/v2/templates/search.mustache
@@ -46,8 +46,8 @@
           </label>
           <select class="govuk-select" id="sort" name="sort">
             <option value="{{ sort.relevant }}" selected>Most relevant</option>
-            <option value="{{ sort.name_az }}">Product name (A to Z)</option>
-            <option value="{{ sort.manufacturer_az }}">Manufacturer name (A to Z)</option>
+            <option id="sort_name" value="{{ sort.name_az }}">Product name (A to Z)</option>
+            <option id="sort_manufacturer" value="{{ sort.manufacturer_az }}">Manufacturer name (A to Z)</option>
           </select>
         </div>
         <h2 class="govuk-heading-s">Filter results</h2>
@@ -1363,6 +1363,24 @@
 
 <script>
 document.addEventListener("DOMContentLoaded", function(event) {
+    /* Make sure correct selection option is set  */
+    const selectDropdown = document.querySelector('select#sort');
+    const urlParams = new URLSearchParams(window.location.search);
+    const sort = urlParams.get('sort');
+    if ( sort ) {
+        var option = document.querySelector('#sort_' + sort);
+        if (option) {
+            option.setAttribute('selected', 'selected');
+        }
+    }
+
+    /* Activate sort when an option is chosen  */
+    selectDropdown.addEventListener('change', function (e) {
+        window.location.href = e.target.value;
+    });
+
+
+    /* Highlight test text */
     sb = document. getElementById("search");
     if (sb.value.toLowerCase().includes("catheter")) {
         const words = sb.value.split(" ").map(function(s) {return s.toLowerCase()});
@@ -1389,6 +1407,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
         }
     }
 });
+
 </script>
 
 {{> layout/footer}}


### PR DESCRIPTION
Allows sorting of the search results by passing a sort parameter in the URL.  This can be

* `-manufacturer`  - the manufacturer name, Z to A
* `manufacturer` - the manufacturer name, A to Z

* `name` - the product name, A to Z
* `-name` - the product name, Z to A