### PR TITLE
Highlight search term in results (for catheter).

### DIFF
--- a/prototypes/v2/static/stylesheets/prototype.css
+++ b/prototypes/v2/static/stylesheets/prototype.css
@@ -24,7 +24,6 @@ dd {
     font-weight: bold;
     padding: 20px 0 40px 0;
     border-bottom: none;
-    
 }
 
 .govuk-header__container {
@@ -54,12 +53,11 @@ a:hover {
     overflow: scroll;
     overflow-y: scroll;
 }
-  
+
 .filters .govuk-details__text {
-    border-left:none;
+    border-left: none;
     padding-left: 0;
 }
-
 
 /* Showing conditional fields within tables */
 .govuk-table__row.conditional .govuk-table__header {
@@ -72,4 +70,9 @@ a:hover {
 .govuk-table__row.conditional .govuk-table__cell {
     border-top: 2px solid #ffffff;
     padding-top: 0px;
+}
+
+.search-result dd b {
+    background: #fffacd;
+    font-weight: normal;
 }

--- a/prototypes/v2/templates/partial/searchresult.mustache
+++ b/prototypes/v2/templates/partial/searchresult.mustache
@@ -1,7 +1,7 @@
 
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-full search-result">
 
     <h3>{{BRAND_TRADE_NAME}} {{# PRODUCT_CODE }} - {{ . }} {{/ PRODUCT_CODE }}</h3>
 
@@ -11,7 +11,7 @@
       </dt>
       <dd>
           {{^ MANUFACTURER_NAME }}  <span class="govuk-hint">Data not available</span> {{/ MANUFACTURER_NAME}}
-          {{# MANUFACTURER_NAME }} {{ . }} {{/MANUFACTURER_NAME}}  
+          {{# MANUFACTURER_NAME }} {{ . }} {{/MANUFACTURER_NAME}}
       </dd>
       <dt>
           Product description:
@@ -24,29 +24,29 @@
       </dt>
       <dd>
           {{^ GMDN_CODE }}  <span class="govuk-hint">Data not available</span> {{/ GMDN_CODE}}
-          {{# GMDN_CODE }} {{ . }} - {{GMDN_TERM_NAME}} {{/GMDN_CODE}}  
-         
+          {{# GMDN_CODE }} {{ . }} - {{GMDN_TERM_NAME}} {{/GMDN_CODE}}
+
       </dd>
       <dt>
           Product Code (MPC):
       </dt>
       <dd>
           {{^ PRODUCT_CODE }}  <span class="govuk-hint">Data not available</span> {{/ PRODUCT_CODE}}
-          {{# PRODUCT_CODE }} {{ . }} {{/PRODUCT_CODE}}  
+          {{# PRODUCT_CODE }} {{ . }} {{/PRODUCT_CODE}}
       </dd>
       <dt>
         UDI-DI:
       </dt>
       <dd>
         {{^ UDI_NUMBER }}  <span class="govuk-hint">Data not available</span> {{/ UDI_NUMBER}}
-        {{# UDI_NUMBER }} {{ . }} {{/UDI_NUMBER}}  
+        {{# UDI_NUMBER }} {{ . }} {{/UDI_NUMBER}}
       </dd>
       <dt>
         Risk class:
       </dt>
       <dd>
           {{^ DEVICE_RISK_SUB_TYPE_DESC }}  <span class="govuk-hint">Data not available</span> {{/ DEVICE_RISK_SUB_TYPE_DESC}}
-          {{# DEVICE_RISK_SUB_TYPE_DESC }} {{ . }} {{/DEVICE_RISK_SUB_TYPE_DESC}}  
+          {{# DEVICE_RISK_SUB_TYPE_DESC }} {{ . }} {{/DEVICE_RISK_SUB_TYPE_DESC}}
       </dd>
       <dt>
         NHS eClass:

--- a/prototypes/v2/templates/search.mustache
+++ b/prototypes/v2/templates/search.mustache
@@ -1361,4 +1361,34 @@
     </div>
   </main>
 
+<script>
+document.addEventListener("DOMContentLoaded", function(event) {
+    sb = document. getElementById("search");
+    if (sb.value.toLowerCase().includes("catheter")) {
+        const words = sb.value.split(" ").map(function(s) {return s.toLowerCase()});
+
+        const elements = document.querySelectorAll("div.search-result dd");
+        for (i in elements ) {
+            let inner = elements[i].innerHTML;
+            if ( inner == undefined ||   inner.includes("govuk-hint")) {
+                continue;
+            }
+
+            let lower = inner.toLowerCase();
+            for (wi in words) {
+                let word = words[wi];
+
+                if (inner.indexOf(word) >= 0 ) {
+                    inner = inner.replace(word, "<b>" + word + "</b>");
+                }
+            }
+
+            if( inner != elements[i].innerHTML ) {
+                elements[i].innerHTML = inner;
+            }
+        }
+    }
+});
+</script>
+
 {{> layout/footer}}


### PR DESCRIPTION
If a specific word appears in the search term, then highlight the results (with Javascript). We would be best doing this highlighting in the back end, but currently our search returns just the IDs of records to show, so it would be problematic to get the hightlighted text from the search results on the page.

Currently, this is triggered by a search containing the word 'catheter', so for example 'reusable catheter' should highlight the words catheter and reusable.