### PR TITLE
Do not obscure "Data not available" message

### DIFF
--- a/prototypes/v2/src/controllers.ts
+++ b/prototypes/v2/src/controllers.ts
@@ -7,7 +7,6 @@ import { parseFmt, getRenderer, RenderTarget } from "./render";
 const PAGE_SIZE: number = 10;
 
 export module Controllers {
-
   export function index(_request: Request, response: Response) {
     getRenderer(RenderTarget.HTML, "home", response)({});
   }
@@ -211,7 +210,7 @@ export module Controllers {
 
 function clean_boolean(val?: string | undefined): string {
   if (val === null || val === undefined || val == "" || val == "NULL") {
-    return "Not specified";
+    return "";
   }
 
   if (val === "0") {

--- a/prototypes/v2/templates/partial/product.mustache
+++ b/prototypes/v2/templates/partial/product.mustache
@@ -37,7 +37,7 @@
           <th scope="row" class="govuk-table__header">Risk class</th>
           <td class="govuk-table__cell">
             {{^ DEVICE_RISK_SUB_TYPE_DESC }}  <span class="govuk-hint">Data not available</span> {{/ DEVICE_RISK_SUB_TYPE_DESC}}
-            {{# DEVICE_RISK_SUB_TYPE_DESC }} {{ . }} {{/DEVICE_RISK_SUB_TYPE_DESC}}  
+            {{# DEVICE_RISK_SUB_TYPE_DESC }} {{ . }} {{/DEVICE_RISK_SUB_TYPE_DESC}}
           </td>
         </tr>
         <tr class="govuk-table__row">
@@ -96,7 +96,7 @@
               <tr class="govuk-table__row">
                 <th scope="row" class="govuk-table__header">Still in production</th>
                 <td class="govuk-table__cell"><span class="govuk-hint">Data not available</span></td>
-              </tr>         
+              </tr>
               <tr class="govuk-table__row conditional">
                 <th scope="row" class="govuk-table__header">Production ended</th>
                 <td class="govuk-table__cell"><span class="govuk-hint">Data not available</span></td>
@@ -286,8 +286,8 @@
               <tr class="govuk-table__row conditional">
                 <th scope="row" class="govuk-table__header">Details of installation requirements</th>
                 <td class="govuk-table__cell"><a href="#">Download&nbsp;requirements</a><br>(PDF, 1.2MB)</td>
-              </tr>            
-            
+              </tr>
+
             </tbody>
           </table>
         </div>
@@ -357,7 +357,7 @@
           </table>
         </div>
       </div>
-      
+
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
@@ -384,7 +384,7 @@
                 {{# SINGLE_USE_DEVICE }} {{ . }} {{/SINGLE_USE_DEVICE}}
               </td>
             </tr>
-          
+
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header">
               Unit of issue
@@ -401,7 +401,7 @@
               </th>
               <td class="govuk-table__cell">
                 {{^ IS_STERILE }}  <span class="govuk-hint">Data not available</span> {{/ IS_STERILE}}
-                {{# IS_STERILE }} {{ . }} {{/IS_STERILE}}
+                {{# IS_STERILE }} {{ IS_STERILE }} {{/IS_STERILE}}
               </td>
             </tr>
               <tr class="govuk-table__row">
@@ -543,7 +543,7 @@
                 <th scope="row" class="govuk-table__header">Details of any additional support facilities offered</th>
                 <td class="govuk-table__cell"><a href="#">Download&nbsp;details</a><br>(PDF, 1.2MB)</td>
               </tr>
-             
+
             </tbody>
           </table>
         </div>
@@ -634,7 +634,7 @@
           </table>
         </div>
       </div>
-      
+
       {{! <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">


### PR DESCRIPTION
For some boolean fields (actually tri/quad state fields) we previously attempted to clean them up. Now we have a pattern for "Data not available", we can just leave the invalid values as "" to pick up the message in the template.