### PR TITLE
Remove unnecessary heading

### DIFF
--- a/prototypes/v2/templates/flag.mustache
+++ b/prototypes/v2/templates/flag.mustache
@@ -1,7 +1,5 @@
 {{> layout/header}}
 
-<h1>Report a problem with data</h1>
-
   <main class="govuk-main-wrapper">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Remove heading that is no longer required to differentiate flag/request pages